### PR TITLE
Downgrade rails dependency to 3.1

### DIFF
--- a/gretel.gemspec
+++ b/gretel.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^test/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails", ">= 3.2.0"
+  gem.add_dependency "rails", ">= 3.1.0"
   gem.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
@abak-press/pullviewers 

крутой гем для построения крошек
у нас есть своё поделие https://github.com/abak-press/apress-breadcrumbs
но оно гавно
есть ещё пичаль - он конфликтует
поэтому рендерить надо так `send(:gretel_renderer).render({options})`
